### PR TITLE
Add HTTP auth and DELETE support, plus GCS documentation

### DIFF
--- a/docs/source/tutorials/http_upload.rst
+++ b/docs/source/tutorials/http_upload.rst
@@ -125,19 +125,13 @@ Google Cloud Storage with:
 
 ``--http_upload_headers \"Authorization: Bearer AUTH_TOKEN\""``
 
-
-HTTPS
-=====
-While there's already some code in place,
-HTTPS is currently not supported yet.
-
 HTTP DELETE
 ===========
-Nothing has been done to support this yet:
+Packager supports removing old segments automatically.  (See
+``preserved_segments_outside_live_window`` option in DASH_ options or HLS_
+options for details.)
 
-    Packager supports removing old segments automatically.
-    See ``preserved_segments_outside_live_window`` option in
-    DASH_ options or HLS_ options for details.
+With HTTP paths, this will be done using HTTP DELETE.
 
 Software tests
 ==============

--- a/docs/source/tutorials/http_upload.rst
+++ b/docs/source/tutorials/http_upload.rst
@@ -54,8 +54,9 @@ with appropriate URLs where the HTTP PUT requests will be issued to.
 You can also supply the ``--user_agent`` flag to specify a custom
 User-Agent string for all HTTP PUT requests.
 
-For pragmatic reasons, all HTTP requests will be declared as
-``Content-Type: application/octet-stream``.
+Content types for mp4, webm, vtt, and ttml files will be set in the HTTP upload.
+Other extensions will be declared as type ``application/octet-stream`` in the
+HTTP request.
 
 Synopsis
 ========

--- a/docs/source/tutorials/http_upload.rst
+++ b/docs/source/tutorials/http_upload.rst
@@ -115,7 +115,16 @@ we should also check DASH_.
 
 Basic Auth
 ==========
-There's no support for authentication yet.
+You can send authentication headers or any other HTTP request headers using
+``--http_upload_headers``.  Headers take the form of ``HEADER: VALUE``, and
+multiple such headers should be separated by newlines (which can't appear in
+HTTP header values).
+
+For example, if your OAuth token is ``AUTH_TOKEN``, you could authenticate to
+Google Cloud Storage with:
+
+``--http_upload_headers \"Authorization: Bearer AUTH_TOKEN\""``
+
 
 HTTPS
 =====
@@ -124,7 +133,7 @@ HTTPS is currently not supported yet.
 
 HTTP DELETE
 ===========
-Nothing has be done to support this yet:
+Nothing has been done to support this yet:
 
     Packager supports removing old segments automatically.
     See ``preserved_segments_outside_live_window`` option in

--- a/docs/source/tutorials/http_upload.rst
+++ b/docs/source/tutorials/http_upload.rst
@@ -228,6 +228,14 @@ Then add the Packager argument::
 
 Where ``AUTH_TOKEN`` is your OAuth 2.0 token for GCS.
 
+For live streams, you should also disable caching so that GCS does not serve a
+stale manifest.  For this, change the argument to::
+
+    --http_upload_headers "Authorization: Bearer AUTH_TOKEN\nCache-Control: no-store, no-transform"
+
+Where ``AUTH_TOKEN`` is your OAuth 2.0 token for GCS and ``\n`` is a literal
+newline.
+
 Finally, to upload to a bucket named BUCKET_NAME and a folder called
 FOLDER_PATH, use the URL
 ``https://BUCKET_NAME.storage.googleapis.com/FOLDER_PATH`` as the base for

--- a/docs/source/tutorials/http_upload.rst
+++ b/docs/source/tutorials/http_upload.rst
@@ -143,10 +143,10 @@ Network timeouts
 libcurl_ can apply network timeout settings. However,
 we haven't addressed this yet.
 
-Miscellaneous
-=============
-- Address all things TODO and FIXME
-- Make ``io_cache_size`` configurable?
+TODO
+====
+- Upload chunks as they are ready instead of buffering whole segments in IOCache
+- Document AWS usage
 
 
 *******
@@ -215,6 +215,25 @@ Run Caddy::
     caddy -conf Caddyfile
 
 
+HTTP PUT file uploads to Google Cloud Storage
+=============================================
+Create an OAuth 2.0 token with access to Google Cloud Storage.  For testing
+purposes, you can use Google's `OAuth Playground`_ to generate a token with
+access to the ``https://www.googleapis.com/auth/devstorage.read_write`` API
+scope.
+
+Then add the Packager argument::
+
+    --http_upload_headers "Authorization: Bearer AUTH_TOKEN"
+
+Where ``AUTH_TOKEN`` is your OAuth 2.0 token for GCS.
+
+Finally, to upload to a bucket named BUCKET_NAME and a folder called
+FOLDER_PATH, use the URL
+``https://BUCKET_NAME.storage.googleapis.com/FOLDER_PATH`` as the base for
+Packager's outputs.
+
+
 *************************
 Development and debugging
 *************************
@@ -248,6 +267,7 @@ Have fun!
 .. _ngx_http_dav_module: http://nginx.org/en/docs/http/ngx_http_dav_module.html
 .. _Caddy: https://caddyserver.com/
 .. _httpd-reflector.py: https://gist.github.com/amotl/3ed38e461af743aeeade5a5a106c1296
+.. _OAuth Playground: https://developers.google.com/oauthplayground/
 
 .. _@colleenkhenry: https://github.com/colleenkhenry
 .. _@kqyang: https://github.com/kqyang

--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -295,8 +295,10 @@ bool File::WriteFileAtomically(const char* file_name,
   // Provide a default implementation which may not be atomic unfortunately.
 
   // Skip the warning message for memory files, which is meant for testing
-  // anyway..
-  if (strncmp(file_name, kMemoryFilePrefix, strlen(kMemoryFilePrefix)) != 0) {
+  // anyway.  Also skip the message for HTTP files.
+  if (strncmp(file_name, kMemoryFilePrefix, strlen(kMemoryFilePrefix)) != 0 &&
+      strncmp(file_name, kHttpFilePrefix, strlen(kHttpFilePrefix)) != 0 &&
+      strncmp(file_name, kHttpsFilePrefix, strlen(kHttpsFilePrefix)) != 0) {
     LOG(WARNING) << "Writing to " << file_name
                  << " is not guaranteed to be atomic.";
   }

--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -103,8 +103,16 @@ File* CreateHttpsFile(const char* file_name, const char* mode) {
   return new HttpFile(file_name, mode, true);
 }
 
+bool DeleteHttpsFile(const char* file_name) {
+  return HttpFile::Delete(file_name, true);
+}
+
 File* CreateHttpFile(const char* file_name, const char* mode) {
   return new HttpFile(file_name, mode, false);
+}
+
+bool DeleteHttpFile(const char* file_name) {
+  return HttpFile::Delete(file_name, false);
 }
 
 File* CreateMemoryFile(const char* file_name, const char* mode) {
@@ -126,8 +134,8 @@ static const FileTypeInfo kFileTypeInfo[] = {
     {kUdpFilePrefix, &CreateUdpFile, nullptr, nullptr},
     {kMemoryFilePrefix, &CreateMemoryFile, &DeleteMemoryFile, nullptr},
     {kCallbackFilePrefix, &CreateCallbackFile, nullptr, nullptr},
-    {kHttpFilePrefix, &CreateHttpFile, nullptr, nullptr},
-    {kHttpsFilePrefix, &CreateHttpsFile, nullptr, nullptr},
+    {kHttpFilePrefix, &CreateHttpFile, &DeleteHttpFile, nullptr},
+    {kHttpsFilePrefix, &CreateHttpsFile, &DeleteHttpsFile, nullptr},
 };
 
 base::StringPiece GetFileTypePrefix(base::StringPiece file_name) {

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -326,7 +326,8 @@ void HttpFile::SetupRequestData(const std::string& data) {
   headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
   headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
 
-  // Don't stop on 200 OK responses.
+  // Don't send the "Expect" header, and therefore don't stop on 200 OK
+  // responses.  Expect is widely ignored by servers.
   headers = curl_slist_append(headers, "Expect:");
 
   // Add any user-specified request headers.

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -118,8 +118,7 @@ bool HttpFile::Open() {
 
 void HttpFile::CurlPut() {
   // Setup libcurl handle with HTTP PUT upload transfer mode.
-  std::string request_body;
-  Request(PUT, resource_url(), request_body, &response_body_);
+  Request(PUT, resource_url(), &response_body_);
 }
 
 bool HttpFile::Close() {
@@ -188,7 +187,6 @@ bool HttpFile::Tell(uint64_t* position) {
 // Perform HTTP request
 Status HttpFile::Request(HttpMethod http_method,
                          const std::string& url,
-                         const std::string& data,
                          std::string* response) {
 
   // TODO: Sanity checks.
@@ -200,7 +198,7 @@ Status HttpFile::Request(HttpMethod http_method,
   SetupRequestBase(http_method, url, response);
 
   // Setup HTTP request headers and body
-  SetupRequestData(data);
+  SetupRequestData();
 
   // Perform HTTP request
   CURLcode res = curl_easy_perform(curl_);
@@ -315,7 +313,7 @@ size_t read_callback(char* buffer, size_t size, size_t nitems, void* stream) {
 }
 
 // Configure curl_ handle for HTTP PUT upload
-void HttpFile::SetupRequestData(const std::string& data) {
+void HttpFile::SetupRequestData() {
 
   // TODO: Sanity checks.
   // if (method == POST || method == PUT || method == PATCH)

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -95,8 +95,8 @@ HttpFile::HttpFile(const char* file_name, const char* mode)
 HttpFile::~HttpFile() {}
 
 bool HttpFile::Open() {
-
-  VLOG(1) << "Opening " << resource_url() << " with file mode \"" << file_mode_ << "\".";
+  VLOG(1) << "Opening " << resource_url_ <<
+             " with file mode \"" << file_mode_ << "\".";
 
   // Ignore read requests as they would truncate the target
   // file by propagating as zero-length PUT requests.
@@ -118,11 +118,11 @@ bool HttpFile::Open() {
 
 void HttpFile::CurlPut() {
   // Setup libcurl handle with HTTP PUT upload transfer mode.
-  Request(PUT, resource_url(), &response_body_);
+  Request(PUT, &response_body_);
 }
 
 bool HttpFile::Close() {
-  VLOG(1) << "Closing " << resource_url() << ".";
+  VLOG(1) << "Closing " << resource_url_ << ".";
   cache_.Close();
   task_exit_event_.Wait();
   delete this;
@@ -135,33 +135,13 @@ int64_t HttpFile::Read(void* buffer, uint64_t length) {
 }
 
 int64_t HttpFile::Write(const void* buffer, uint64_t length) {
-  std::string url = resource_url();
-
-  VLOG(2) << "Writing to " << url << ", length=" << length;
+  VLOG(2) << "Writing to " << resource_url_ << ", length=" << length;
 
   // TODO: Implement retrying with exponential backoff, see
   // "widevine_key_source.cc"
-  Status status;
-
   uint64_t bytes_written = cache_.Write(buffer, length);
   VLOG(3) << "PUT CHUNK bytes_written: " << bytes_written;
   return bytes_written;
-
-  // Debugging based on response status
-  /*
-  if (status.ok()) {
-    VLOG(1) << "Writing chunk succeeded";
-
-  } else {
-    VLOG(1) << "Writing chunk failed";
-    if (!response_body.empty()) {
-      VLOG(2) << "Response:\n" << response_body;
-    }
-  }
-  */
-
-  // Always signal success to the downstream pipeline
-  return length;
 }
 
 int64_t HttpFile::Size() {
@@ -184,21 +164,28 @@ bool HttpFile::Tell(uint64_t* position) {
   return false;
 }
 
+bool HttpFile::Delete() {
+  VLOG(2) << "Deleting " << resource_url_;
+  Status status = Request(DELETE, &response_body_);
+  return status == Status::OK;
+}
+
+// static
+bool HttpFile::Delete(const char* file_name, bool https) {
+  HttpFile file(file_name, "w", https);
+  return file.Delete();
+}
+
 // Perform HTTP request
 Status HttpFile::Request(HttpMethod http_method,
-                         const std::string& url,
                          std::string* response) {
-
-  // TODO: Sanity checks.
-  // DCHECK(http_method == GET || http_method == POST);
-
-  VLOG(1) << "Sending request to URL " << url;
+  VLOG(1) << "Sending request to URL " << resource_url_;
 
   // Setup HTTP method and libcurl options
-  SetupRequestBase(http_method, url, response);
+  SetupRequestBase(http_method, response);
 
   // Setup HTTP request headers and body
-  SetupRequestData();
+  SetupRequestData(http_method);
 
   // Perform HTTP request
   CURLcode res = curl_easy_perform(curl_);
@@ -211,7 +198,7 @@ Status HttpFile::Request(HttpMethod http_method,
     std::string method_text = method_as_text(http_method);
     std::string error_message = base::StringPrintf(
         "%s request for %s failed. Reason: %s.", method_text.c_str(),
-        url.c_str(), curl_easy_strerror(res));
+        resource_url_.c_str(), curl_easy_strerror(res));
     if (res == CURLE_HTTP_RETURNED_ERROR) {
       long response_code = 0;
       curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &response_code);
@@ -236,9 +223,7 @@ Status HttpFile::Request(HttpMethod http_method,
 }
 
 // Configure curl_ handle with reasonable defaults
-void HttpFile::SetupRequestBase(HttpMethod http_method,
-                                const std::string& url,
-                                std::string* response) {
+void HttpFile::SetupRequestBase(HttpMethod http_method, std::string* response) {
   response->clear();
 
   // Configure HTTP request method/verb
@@ -255,10 +240,13 @@ void HttpFile::SetupRequestBase(HttpMethod http_method,
     case PATCH:
       curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "PATCH");
       break;
+    case DELETE:
+      curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "DELETE");
+      break;
   }
 
   // Configure HTTP request
-  curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl_, CURLOPT_URL, resource_url_.c_str());
 
   if (user_agent_.empty()) {
     curl_easy_setopt(curl_, CURLOPT_USERAGENT, kUserAgentString);
@@ -313,16 +301,9 @@ size_t read_callback(char* buffer, size_t size, size_t nitems, void* stream) {
 }
 
 // Configure curl_ handle for HTTP PUT upload
-void HttpFile::SetupRequestData() {
-
-  // TODO: Sanity checks.
-  // if (method == POST || method == PUT || method == PATCH)
-
+void HttpFile::SetupRequestData(HttpMethod http_method) {
   // Build list of HTTP request headers.
   struct curl_slist* headers = nullptr;
-
-  headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
-  headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
 
   // Don't send the "Expect" header, and therefore don't stop on 200 OK
   // responses.  Expect is widely ignored by servers.
@@ -335,10 +316,24 @@ void HttpFile::SetupRequestData() {
     headers = curl_slist_append(headers, user_headers[i].c_str());
   }
 
-  // Enable progressive upload with chunked transfer encoding.
-  curl_easy_setopt(curl_, CURLOPT_READFUNCTION, read_callback);
-  curl_easy_setopt(curl_, CURLOPT_READDATA, &cache_);
-  curl_easy_setopt(curl_, CURLOPT_UPLOAD, 1L);
+  switch (http_method) {
+    case POST:
+    case PUT:
+    case PATCH:
+      // For methods that transfer data, set appropriate headers.
+      headers = curl_slist_append(headers,
+          "Content-Type: application/octet-stream");
+      headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
+
+      // Enable progressive upload with chunked transfer encoding.
+      curl_easy_setopt(curl_, CURLOPT_READFUNCTION, read_callback);
+      curl_easy_setopt(curl_, CURLOPT_READDATA, &cache_);
+      curl_easy_setopt(curl_, CURLOPT_UPLOAD, 1L);
+      break;
+
+    default:
+      break;
+  }
 
   // Add HTTP request headers.
   curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers);
@@ -359,6 +354,9 @@ std::string HttpFile::method_as_text(HttpMethod method) {
       break;
     case PATCH:
       method_text = "PATCH";
+      break;
+    case DELETE:
+      method_text = "DELETE";
       break;
   }
   return method_text;

--- a/packager/file/http_file.h
+++ b/packager/file/http_file.h
@@ -128,6 +128,7 @@ class HttpFile : public File {
   const char* file_mode_;
   std::string resource_url_;
   std::string user_agent_;
+  std::string user_headers_;
   std::string ca_file_;
   std::string cert_file_;
   std::string cert_private_key_file_;

--- a/packager/file/http_file.h
+++ b/packager/file/http_file.h
@@ -89,6 +89,10 @@ class HttpFile : public File {
   bool Tell(uint64_t* position) override;
   /// @}
 
+  bool Delete();
+
+  static bool Delete(const char* file_name, bool https);
+
   /// @return The full resource url
   const std::string& resource_url() const { return resource_url_; }
 
@@ -104,21 +108,18 @@ class HttpFile : public File {
     POST,
     PUT,
     PATCH,
+    DELETE,
   };
 
   HttpFile(const HttpFile&) = delete;
   HttpFile& operator=(const HttpFile&) = delete;
 
   // Internal implementation of HTTP functions, e.g. Get and Post.
-  Status Request(HttpMethod http_method,
-                 const std::string& url,
-                 std::string* response);
+  Status Request(HttpMethod http_method, std::string* response);
 
-  void SetupRequestBase(HttpMethod http_method,
-                        const std::string& url,
-                        std::string* response);
+  void SetupRequestBase(HttpMethod http_method, std::string* response);
 
-  void SetupRequestData();
+  void SetupRequestData(HttpMethod http_method);
 
   void CurlPut();
 

--- a/packager/file/http_file.h
+++ b/packager/file/http_file.h
@@ -112,14 +112,13 @@ class HttpFile : public File {
   // Internal implementation of HTTP functions, e.g. Get and Post.
   Status Request(HttpMethod http_method,
                  const std::string& url,
-                 const std::string& data,
                  std::string* response);
 
   void SetupRequestBase(HttpMethod http_method,
                         const std::string& url,
                         std::string* response);
 
-  void SetupRequestData(const std::string& data);
+  void SetupRequestData();
 
   void CurlPut();
 


### PR DESCRIPTION
Building on google/shaka-packager#737, this adds HTTP auth support, which would allow direct upload to cloud services such as GCS.